### PR TITLE
Adding attesters

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+use_small_heuristics = "Max"
+reorder_imports = true
+edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,25 @@ use near_sdk::serde::{Serialize, Deserialize};
 
 near_sdk::setup_alloc!();
 
+type AttestationId = u64;
+type AttesterId = AccountId;
+
 
 #[derive(BorshSerialize, BorshStorageKey)]
 enum StorageKey {
     Ideas,
     Submissions,
+    Attestations,
+    Sponsorships,
 }
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[serde(crate = "near_sdk::serde")]
+pub struct Attestation {
+    attester: AccountId,
+    description: String,
+}
+
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(crate = "near_sdk::serde")]
@@ -76,6 +89,7 @@ pub struct Submission {
     description: String,
     #[serde(with = "u64_dec_format")]
     timestamp: Timestamp,
+    attestations: Vec<AttestationId>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
@@ -91,8 +105,8 @@ pub struct Contract {
     pub default_reviewer_id: AccountId,
     pub ideas: Vector<Idea>,
     pub submissions: LookupMap<u64, Vec<Submission>>,
+    pub attestations: Vector<Attestation>,
 }
-
 
 #[near_bindgen]
 impl Contract {
@@ -102,6 +116,7 @@ impl Contract {
             default_reviewer_id,
             ideas: Vector::new(StorageKey::Ideas),
             submissions: LookupMap::new(StorageKey::Submissions),
+            attestations: Vector::new(StorageKey::Attestations)
         }
     }
 
@@ -149,6 +164,7 @@ impl Contract {
             account_id: env::predecessor_account_id(),
             description: submission.description,
             timestamp: env::block_timestamp(),
+            attestations: vec![]
         });
         self.submissions.insert(&idea_id, &submissions);
     }


### PR DESCRIPTION
This functionality will replace reviewers of the ideas (would need to remove reviewers). This is because there can be multiple sponsors per idea (NF, private sponsors, NDC, Proximity Labs, etc) and they can designate different money overseers/reviewers (Work Groups, individuals, etc). Reviewers can decide on what is passable based on different criteria (someone can say it is okay to pay someone without a security audit). 

Basically a reviewer needs to be decoupled into two personalities:
* Attester -- someone who validates certain claims (e.g. this passes security audit or this is a meaningful architecture);
* Overseer -- someone who makes sure the execution goes well and the money are spent correctly (e.g. work group and DAO);