### PR TITLE
Github board configuration as unchecked JSON string

### DIFF
--- a/src/community.rs
+++ b/src/community.rs
@@ -4,13 +4,6 @@ use near_sdk::{env, AccountId};
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct Github {
-    pub repo: String,
-    pub labels: Vec<String>,
-}
-
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
-#[serde(crate = "near_sdk::serde")]
 pub struct Community {
     pub name: String,
     pub description: String,
@@ -21,7 +14,8 @@ pub struct Community {
     pub admins: Vec<AccountId>,
     pub labels: Vec<String>,
     pub telegram_handles: Vec<String>,
-    pub github: Vec<Github>,
+    /// JSON string of github board configuration
+    pub github: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]

--- a/src/community.rs
+++ b/src/community.rs
@@ -15,7 +15,7 @@ pub struct Community {
     pub labels: Vec<String>,
     pub telegram_handles: Vec<String>,
     /// JSON string of github board configuration
-    pub github: String,
+    pub github: Option<String>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Should be a good temporary solution for now, before we moving away from contract based approach. Still use `edit_community` to modify github field of a community. JSON is unchecked but given only community admins can edit it, and they would do it from UI, we can assume valid format of board configuration is stored.

Since we have not store any community in production contract, migration part is unchanged.
