### PR TITLE
changes to reflect latest community design

### DIFF
--- a/src/community.rs
+++ b/src/community.rs
@@ -4,24 +4,32 @@ use near_sdk::{env, AccountId};
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
+pub struct Wiki {
+    name: String,
+    content_markdown: String,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
+#[serde(crate = "near_sdk::serde")]
 pub struct Community {
     pub name: String,
     pub description: String,
     pub image_url: String,
     pub thumbnail_url: String,
-    pub overview_page_markdown: String,
-    pub events_page_markdown: String,
+    pub wiki1: Option<Wiki>,
+    pub wiki2: Option<Wiki>,
     pub admins: Vec<AccountId>,
-    pub labels: Vec<String>,
-    pub telegram_handles: Vec<String>,
+    pub tag: String,
+    pub telegram_handle: Option<String>,
     /// JSON string of github board configuration
     pub github: Option<String>,
+    pub sponsorship: bool,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
 pub struct CommunityCard {
-    pub slug: String,
+    pub handle: String,
     pub name: String,
     pub description: String,
     pub image_url: String,
@@ -34,9 +42,6 @@ impl Community {
         }
         if self.description.len() > 60 {
             panic!("Community description is limit to 60 characters");
-        }
-        if self.labels.len() == 0 {
-            panic!("At least one primary label is required");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,17 +324,17 @@ impl Contract {
         notify::notify_edit(id, post_author);
     }
 
-    pub fn add_community(&mut self, slug: String, mut community: Community) {
-        if self.communities.get(&slug).is_some() {
+    pub fn add_community(&mut self, handle: String, mut community: Community) {
+        if self.communities.get(&handle).is_some() {
             panic!("Community already exists");
         }
         community.validate();
         community.set_default_admin();
-        self.communities.insert(&slug, &community);
+        self.communities.insert(&handle, &community);
     }
 
-    pub fn edit_community(&mut self, slug: String, mut community: Community) {
-        let community_old = self.communities.get(&slug).expect("Community does not exist");
+    pub fn edit_community(&mut self, handle: String, mut community: Community) {
+        let community_old = self.communities.get(&handle).expect("Community does not exist");
         let moderators = self.access_control.members_list.get_moderators();
         let editor = env::predecessor_account_id();
         if !community_old.admins.contains(&editor)
@@ -345,15 +345,15 @@ impl Contract {
 
         community.validate();
         community.set_default_admin();
-        self.communities.insert(&slug, &community);
+        self.communities.insert(&handle, &community);
     }
 
     pub fn get_all_communities(&self) -> Vec<CommunityCard> {
         near_sdk::log!("get_all_communities");
         self.communities
             .iter()
-            .map(|(slug, community)| CommunityCard {
-                slug,
+            .map(|(handle, community)| CommunityCard {
+                handle,
                 name: community.name,
                 description: community.description,
                 image_url: community.image_url,
@@ -361,7 +361,7 @@ impl Contract {
             .collect()
     }
 
-    pub fn get_community(&self, slug: String) -> Option<Community> {
-        self.communities.get(&slug)
+    pub fn get_community(&self, handle: String) -> Option<Community> {
+        self.communities.get(&handle)
     }
 }


### PR DESCRIPTION
Resolves #27 .

For @near-akaia-root: I deployed a version to testnet, you can interact with it with near-cli using these commands:
```sh


export contract=m.zxcvn.testnet

near call $contract add_community --accountId k.zxcvn.testnet --args '{"handle":"zkp2", "community":{"name":"zero knowledge", "description":"a community discussing zkp on NEAR", "image_url":"https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu", "thumbnail_url":"https://ipfs.near.social/ipfs/bafkreiajwq6ep3n7veddozji2djv5vviyisabhycbweslvpwhsoyuzcwi4","wiki1":{"name":"overview", "content_markdown":"Zero Knowledge (ZK) technology is gaining significant traction within the NEAR community. This space brings together individuals, experts, and organizations who are interested in developing a ZK ecosystem on NEAR. Our vision is to drive the development of ZK technology and explore its potential applications.Our GroupsThe Zero Knowledge community consists of two main groups:..."},"wiki2":null, "admins":[], "tag":"zero-knowledge","telegram_handle":null,"github":null,"sponsorship":true}}'
near call $contract edit_community --accountId k.zxcvn.testnet --args '{"handle":"zkp2", "community":{"name":"zero knowledge 2", "description":"a community discussing zkp on NEAR", "image_url":"https://ipfs.near.social/ipfs/bafkreihgxg5kwts2juldaeasveyuddkm6tcabmrat2aaq5u6uyljtyt7lu", "thumbnail_url":"https://ipfs.near.social/ipfs/bafkreiajwq6ep3n7veddozji2djv5vviyisabhycbweslvpwhsoyuzcwi4","wiki1":{"name":"overview", "content_markdown":"Zero Knowledge (ZK) technology is gaining significant traction within the NEAR community. This space brings together individuals, experts, and organizations who are interested in developing a ZK ecosystem on NEAR. Our vision is to drive the development of ZK technology and explore its potential applications.Our GroupsThe Zero Knowledge community consists of two main groups:..."},"wiki2":null, "admins":[], "tag":"zero-knowledge","telegram_handle":null,"github":null,"sponsorship":true}}'
near view $contract get_all_communities
near view $contract get_community '{"handle":"zkp2"}'
```