### PR TITLE
feat: notify of mentions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  rununittest:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unit tests
+        run: |
+          cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ version = "0.1.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ crate-type = ["cdylib"]
 near-sdk = "3.1.0"
 near-contract-standards = "3.2.0"
 
+[dev-dependencies]
+regex = "1"
+
 [profile.release]
 codegen-units = 1
 # Tell `rustc` to optimize for small code size.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,14 @@ impl Contract {
         author_posts.insert(post.id);
         self.authors.insert(&post.author_id, &author_posts);
 
+        let desc = match post.snapshot.body.clone() {
+            PostBody::Comment(comment) => comment.latest_version().description,
+            PostBody::Idea(idea) => idea.latest_version().description,
+            PostBody::Submission(submission) => submission.latest_version().description,
+            PostBody::Attestation(attestation) => attestation.latest_version().description,
+            PostBody::Sponsorship(sponsorship) => sponsorship.latest_version().description,
+        };
+
         if parent_id != ROOT_POST_ID {
             let parent_post: Post = self
                 .posts
@@ -180,6 +188,8 @@ impl Contract {
         } else {
             repost::repost(post);
         }
+        
+        notify::notify_mentions(desc.as_str(), id);
     }
 
     pub fn get_posts_by_author(&self, author: AccountId) -> Vec<PostId> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,7 @@ impl Contract {
         author_posts.insert(post.id);
         self.authors.insert(&post.author_id, &author_posts);
 
-        let desc = match post.snapshot.body.clone() {
-            PostBody::Comment(comment) => comment.latest_version().description,
-            PostBody::Idea(idea) => idea.latest_version().description,
-            PostBody::Submission(submission) => submission.latest_version().description,
-            PostBody::Attestation(attestation) => attestation.latest_version().description,
-            PostBody::Sponsorship(sponsorship) => sponsorship.latest_version().description,
-        };
+        let desc = get_post_description(post.clone());
 
         if parent_id != ROOT_POST_ID {
             let parent_post: Post = self
@@ -375,10 +369,10 @@ mod tests {
     use std::collections::HashSet;
     use std::convert::TryInto;
 
-    use near_sdk::test_utils::{VMContextBuilder,get_created_receipts};
+    use crate::post::PostBody;
+    use near_sdk::test_utils::{get_created_receipts, VMContextBuilder};
     use near_sdk::{testing_env, MockedBlockchain, VMContext};
     use regex::Regex;
-    use crate::post::PostBody;
 
     use super::Contract;
 
@@ -415,12 +409,23 @@ mod tests {
 
             let args = &cap[2];
 
-            let method_name = method_name.trim_start_matches('[').trim_end_matches(']').split(", ").map(|s| s.parse().unwrap()).collect::<Vec<u8>>();
-            let method_name = String::from_utf8(method_name).expect("Failed to convert method_name to String");
+            let method_name = method_name
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .split(", ")
+                .map(|s| s.parse().unwrap())
+                .collect::<Vec<u8>>();
+            let method_name =
+                String::from_utf8(method_name).expect("Failed to convert method_name to String");
 
             assert_eq!("set", method_name);
 
-            let args = args.trim_start_matches('[').trim_end_matches(']').split(", ").map(|s| s.parse().unwrap()).collect::<Vec<u8>>();
+            let args = args
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .split(", ")
+                .map(|s| s.parse().unwrap())
+                .collect::<Vec<u8>>();
             let args = String::from_utf8(args).expect("Failed to convert args to String");
 
             assert_eq!("{\"data\":{\"bob.near\":{\"index\":{\"notify\":\"[{\\\"key\\\":\\\"petersalomonsen.near\\\",\\\"value\\\":{\\\"type\\\":\\\"devgovgigs/mention\\\",\\\"post\\\":0}},{\\\"key\\\":\\\"psalomo.near.\\\",\\\"value\\\":{\\\"type\\\":\\\"devgovgigs/mention\\\",\\\"post\\\":0}}]\"}}}}", args);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,11 +185,11 @@ impl Contract {
                 .into();
             let parent_author = parent_post.author_id;
             notify::notify_reply(parent_id, parent_author);
+            notify::notify_mentions(desc.as_str(), id);
         } else {
             repost::repost(post);
+            notify::notify_mentions(desc.as_str(), id);
         }
-        
-        notify::notify_mentions(desc.as_str(), id);
     }
 
     pub fn get_posts_by_author(&self, author: AccountId) -> Vec<PostId> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,11 +185,10 @@ impl Contract {
                 .into();
             let parent_author = parent_post.author_id;
             notify::notify_reply(parent_id, parent_author);
-            notify::notify_mentions(desc.as_str(), id);
         } else {
             repost::repost(post);
-            notify::notify_mentions(desc.as_str(), id);
         }
+        notify::notify_mentions(desc.as_str(), id);
     }
 
     pub fn get_posts_by_author(&self, author: AccountId) -> Vec<PostId> {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -91,3 +91,62 @@ fn notify(post_id: PostId, post_author: AccountId, action: &str) -> Promise {
         env::prepaid_gas() / 4,
     )
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::convert::TryInto;
+
+    use super::notify_mentions;
+
+    use near_sdk::test_utils::{VMContextBuilder,get_created_receipts};
+    use near_sdk::{testing_env, MockedBlockchain, VMContext};
+    
+    use regex::Regex;
+
+    fn get_context(is_view: bool) -> VMContext {
+        VMContextBuilder::new()
+            .signer_account_id("bob.near".try_into().unwrap())
+            .is_view(is_view)
+            .build()
+    }
+
+    #[test]
+    pub fn test_notify_mentions() {
+        let context = get_context(false);
+        testing_env!(context);
+        let text = "Mentioning @a.near and @bcdefg.near";
+        notify_mentions(text, 2);
+        let receipts = get_created_receipts();
+        assert_eq!(1, receipts.len());
+
+        let receipt = receipts.get(0).unwrap();
+        let receipt_str = format!("{:?}", receipt);
+        let re = Regex::new(r#"method_name: (\[[^\]]*\]), args: (\[[^\]]*\])"#).unwrap();
+
+        // Extract the method_name and args values
+        for cap in re.captures_iter(&receipt_str) {
+            let method_name = &cap[1];
+
+            let args = &cap[2];
+
+            let method_name = method_name.trim_start_matches('[').trim_end_matches(']').split(", ").map(|s| s.parse().unwrap()).collect::<Vec<u8>>();
+            let method_name = String::from_utf8(method_name).expect("Failed to convert method_name to String");
+
+            assert_eq!("set", method_name);
+
+            let args = args.trim_start_matches('[').trim_end_matches(']').split(", ").map(|s| s.parse().unwrap()).collect::<Vec<u8>>();
+            let args = String::from_utf8(args).expect("Failed to convert args to String");
+
+            assert_eq!("{\"data\":{\"bob.near\":{\"index\":{\"notify\":\"[{\\\"key\\\":\\\"a.near\\\",\\\"value\\\":{\\\"type\\\":\\\"devgovgigs/mention\\\",\\\"post\\\":2}},{\\\"key\\\":\\\"bcdefg.near\\\",\\\"value\\\":{\\\"type\\\":\\\"devgovgigs/mention\\\",\\\"post\\\":2}}]\"}}}}", args);
+        }
+    }
+
+    #[test]
+    pub fn test_no_mentions() {
+        let context = get_context(false);
+        testing_env!(context);
+        let text = "Not mentioning anyone";
+        notify_mentions(text, 2);
+        assert_eq!(0, get_created_receipts().len());
+    }
+}

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -32,6 +32,7 @@ pub fn notify_mentions(text: &str, post_id: PostId) {
     }
 
     for mention in &mentions {
+        near_sdk::log!(mention);
         notify_mention(post_id, mention.to_string());
     }
 }
@@ -69,6 +70,6 @@ fn notify(post_id: PostId, post_author: AccountId, action: &str) -> Promise {
         }),
         &SOCIAL_DB,
         env::attached_deposit(),
-        env::prepaid_gas() / 2,
+        env::prepaid_gas() / 4,
     )
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -38,7 +38,7 @@ pub fn notify_mentions(text: &str, post_id: PostId) {
             notify_values.push(json!({
                 "key": mention,
                 "value": {
-                    "type": format!("devgovgigs/{}", "mention"),
+                    "type": "devgovgigs/mention",
                     "post": post_id,
                 }
             }));

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -3,8 +3,45 @@ use crate::PostId;
 use near_sdk::serde_json::json;
 use near_sdk::{env, AccountId, Promise};
 
+pub fn notify_mentions(text: &str, post_id: PostId) {
+    let mut mentions = Vec::new();
+    let mut mention = String::new();
+    let mut recording = false;
+
+    for ch in text.chars() {
+        if recording {
+            if ch.is_alphanumeric() || ch == '.' {
+                mention.push(ch);
+            } else {
+                if !mention.is_empty() {
+                    mentions.push(mention.clone());
+                    mention.clear();
+                }
+                recording = false;
+            }
+        }
+
+        if ch == '@' {
+            recording = true;
+        }
+    }
+
+    // Push the last mention if it wasn't pushed yet
+    if recording && !mention.is_empty() {
+        mentions.push(mention);
+    }
+
+    for mention in &mentions {
+        notify_mention(post_id, mention.to_string());
+    }
+}
+
 pub fn notify_like(post_id: PostId, post_author: AccountId) -> Promise {
     notify(post_id, post_author, "like")
+}
+
+pub fn notify_mention(post_id: PostId, mentioned_account: AccountId) -> Promise {
+    notify(post_id, mentioned_account, "mention")
 }
 
 pub fn notify_reply(post_id: PostId, post_author: AccountId) -> Promise {

--- a/src/post/mod.rs
+++ b/src/post/mod.rs
@@ -110,3 +110,13 @@ pub enum PostBody {
     Attestation(VersionedAttestation),
     Sponsorship(VersionedSponsorship),
 }
+
+pub fn get_post_description(post: Post) -> String {
+    return match post.snapshot.body.clone() {
+        PostBody::Comment(comment) => comment.latest_version().description,
+        PostBody::Idea(idea) => idea.latest_version().description,
+        PostBody::Submission(submission) => submission.latest_version().description,
+        PostBody::Attestation(attestation) => attestation.latest_version().description,
+        PostBody::Sponsorship(sponsorship) => sponsorship.latest_version().description,
+    };
+}

--- a/src/repost.rs
+++ b/src/repost.rs
@@ -1,4 +1,4 @@
-use crate::post::{Post, PostBody};
+use crate::post::{get_post_description, Post, PostBody};
 use crate::social_db::{ext_social_db, SOCIAL_DB};
 use near_sdk::serde_json::json;
 use near_sdk::{env, AccountId, Promise};
@@ -19,13 +19,7 @@ fn repost_internal(post: Post, contract_address: AccountId) -> near_sdk::serde_j
         _ => Default::default(),
     };
 
-    let desc = match post.snapshot.body.clone() {
-        PostBody::Comment(comment) => comment.latest_version().description,
-        PostBody::Idea(idea) => idea.latest_version().description,
-        PostBody::Submission(submission) => submission.latest_version().description,
-        PostBody::Attestation(attestation) => attestation.latest_version().description,
-        PostBody::Sponsorship(sponsorship) => sponsorship.latest_version().description,
-    };
+    let desc = get_post_description(post.clone());
 
     let text = format!(
         "@{author} [Posted on Developer DAO Board]({post_link})\n{title}{desc}",

--- a/src/repost.rs
+++ b/src/repost.rs
@@ -58,7 +58,7 @@ pub fn repost(post: Post) -> Promise {
         repost_internal(post, env::current_account_id()),
         &SOCIAL_DB,
         env::attached_deposit(),
-        env::prepaid_gas() / 2,
+        env::prepaid_gas() / 3,
     )
 }
 


### PR DESCRIPTION
https://github.com/near/neardevhub-widgets/issues/52

## Status
The smart contract scans the text in the post looking for mentions, and if found, notify the mentioned accounts.

Preview URL (unfortunately testnet does not seem to support notifications, so this is on the mainnet):

https://near.social/#/devgovgigs.petersalomonsen.near/widget/gigs-board.pages.Feed

The  `devgovgigs/mention` notification type is implemented this is done in the widget ui, but is not visible for the preview since notification view is handled by the widget deployed to prod. See the widget ui implementation here: https://github.com/near/neardevhub-widgets/pull/151

I've also added unit tests for adding post with mentions
