### PR TITLE
fix bypass permission check to override community

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ impl Contract {
             self.communities.insert(&handle, &community);
         } else {
             if self.communities.get(&community.handle).is_some() {
-                panic!("Renamed community already exists");
+                panic!("Community handle '{}' is already taken", community.handle);
             }
             self.communities.remove(&handle);
             self.communities.insert(&community.handle, &community);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,8 +352,15 @@ impl Contract {
         let _ = self.get_community_for_editing(&handle);
         community.validate();
         community.set_default_admin();
-        self.communities.remove(&handle);
-        self.communities.insert(&community.handle, &community);
+        if handle == community.handle {
+            self.communities.insert(&handle, &community);
+        } else {
+            if self.communities.get(&community.handle).is_some() {
+                panic!("Renamed community already exists");
+            }
+            self.communities.remove(&handle);
+            self.communities.insert(&community.handle, &community);
+        }
     }
 
     pub fn edit_community_github(&mut self, handle: String, github: Option<String>) {


### PR DESCRIPTION
I found this impl has a security problem:
```rs
    pub fn edit_community(&mut self, handle: String, mut community: Community) {
        let _ = self.get_community_for_editing(&handle);
        community.validate();
        community.set_default_admin();
        self.communities.remove(&handle);
        self.communities.insert(&community.handle, &community);
    }
```
you can set community.handle to some existing community to bypass the permission check, to override other communities. This PR fix that.