### PR TITLE
allow multiple telegram handles for a community

### DIFF
--- a/src/access_control/members.rs
+++ b/src/access_control/members.rs
@@ -402,12 +402,7 @@ mod tests {
             Member::Account("thomasguntenaar.near".to_string()),
             MemberMetadata {
                 description: "Account has `Any` rules without labels".to_string(),
-                permissions: HashMap::from([
-                    (
-                        Rule::Any(),
-                        given_permissions.clone(),
-                    ),
-                ]),
+                permissions: HashMap::from([(Rule::Any(), given_permissions.clone())]),
                 ..Default::default()
             }
             .into(),
@@ -420,7 +415,10 @@ mod tests {
 
         // With labels
         assert_eq!(
-            list.check_permissions("thomasguntenaar.near".to_string(), vec!["funding-requested".to_string()]),
+            list.check_permissions(
+                "thomasguntenaar.near".to_string(),
+                vec!["funding-requested".to_string()]
+            ),
             given_permissions,
         )
     }

--- a/src/community.rs
+++ b/src/community.rs
@@ -11,7 +11,7 @@ pub struct WikiPage {
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
-pub struct Community {
+pub struct OldCommunityV1 {
     pub handle: String,
     pub admins: Vec<AccountId>,
     pub name: String,
@@ -31,6 +31,68 @@ pub struct Community {
     pub wiki2: Option<WikiPage>,
 }
 
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub struct Community {
+    pub handle: String,
+    pub admins: Vec<AccountId>,
+    pub name: String,
+    pub description: String,
+    pub bio_markdown: Option<String>,
+    pub logo_url: String,
+    pub banner_url: String,
+    pub tag: String,
+    pub github_handle: Option<String>,
+    pub telegram_handle: Vec<String>,
+    pub twitter_handle: Option<String>,
+    pub website_url: Option<String>,
+    /// JSON string of github board configuration
+    pub github: Option<String>,
+    pub sponsorship: Option<bool>,
+    pub wiki1: Option<WikiPage>,
+    pub wiki2: Option<WikiPage>,
+}
+
+impl From<OldCommunityV1> for Community {
+    fn from(old_community: OldCommunityV1) -> Self {
+        let OldCommunityV1 {
+            handle,
+            admins,
+            name,
+            description,
+            bio_markdown,
+            logo_url,
+            banner_url,
+            tag,
+            github_handle,
+            telegram_handle,
+            twitter_handle,
+            website_url,
+            github,
+            sponsorship,
+            wiki1,
+            wiki2,
+        } = old_community;
+        Community {
+            handle,
+            admins,
+            name,
+            description,
+            bio_markdown,
+            logo_url,
+            banner_url,
+            tag,
+            github_handle,
+            twitter_handle,
+            website_url,
+            github,
+            sponsorship,
+            wiki1,
+            wiki2,
+            telegram_handle: telegram_handle.iter().cloned().collect(),
+        }
+    }
+}
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
 pub struct FeaturedCommunity {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub struct Contract {
 impl Contract {
     #[init]
     pub fn new() -> Self {
-        migrations::state_version_write(&migrations::StateVersion::V4);
+        migrations::state_version_write(&migrations::StateVersion::V6);
         let mut contract = Self {
             posts: Vector::new(StorageKey::Posts),
             post_to_parent: LookupMap::new(StorageKey::PostToParent),
@@ -418,21 +418,18 @@ impl Contract {
             self.is_moderator(env::predecessor_account_id()),
             "Only moderators can add featured communities"
         );
-    
+
         // Check if every handle corresponds to an existing community
         for handle in &handles {
             if !self.communities.get(&handle).is_some() {
                 panic!("Community '{}' does not exist.", handle);
-            }   
+            }
         }
-    
+
         // Replace the existing featured communities with the new ones
-        self.featured_communities = handles
-            .into_iter()
-            .map(|handle| FeaturedCommunity { handle })
-            .collect();
+        self.featured_communities =
+            handles.into_iter().map(|handle| FeaturedCommunity { handle }).collect();
     }
-    
 
     pub fn get_featured_communities(&self) -> Vec<Community> {
         self.featured_communities
@@ -445,7 +442,6 @@ impl Contract {
         let moderators = self.access_control.members_list.get_moderators();
         moderators.contains(&Member::Account(account_id))
     }
-
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -193,14 +193,17 @@ impl Contract {
             label_to_posts,
             access_control,
             authors,
-            communities,
+            mut communities,
             featured_communities,
         } = env::state_read().unwrap();
 
+        let migrated_communties: Vec<(String, Community)> =
+            communities.iter().map(|(k, v)| (k, v.into())).collect();
+        communities.clear();
+
         let mut communities_new = UnorderedMap::new(StorageKey::Communities);
-        for (k, v) in communities.iter() {
-            let community_new = &v.into();
-            communities_new.insert(&k, community_new);
+        for (k, v) in migrated_communties {
+            communities_new.insert(&k, &v);
         }
 
         env::state_write(&Contract {

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -2,6 +2,7 @@
 //! Should be invocable only by the owner and in most cases should be called only once though the
 //! latter is not asserted.
 
+use crate::community::OldCommunityV1;
 use crate::*;
 use near_sdk::{env, near_bindgen, Promise};
 use std::cmp::min;
@@ -140,10 +141,10 @@ pub struct OldContractV4 {
     pub label_to_posts: UnorderedMap<String, HashSet<PostId>>,
     pub access_control: AccessControl,
     pub authors: UnorderedMap<AccountId, HashSet<PostId>>,
-    pub communities: UnorderedMap<String, Community>,
+    pub communities: UnorderedMap<String, OldCommunityV1>,
 }
 
-// From OldContractV3 to Contract
+// From OldContractV4 to Contract
 #[near_bindgen]
 impl Contract {
     fn unsafe_add_featured_communities() {
@@ -156,7 +157,7 @@ impl Contract {
             authors,
             communities,
         } = env::state_read().unwrap();
-        env::state_write(&Contract {
+        env::state_write(&OldContractV5 {
             posts,
             post_to_parent,
             post_to_children,
@@ -169,6 +170,52 @@ impl Contract {
     }
 }
 
+#[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
+pub struct OldContractV5 {
+    pub posts: Vector<VersionedPost>,
+    pub post_to_parent: LookupMap<PostId, PostId>,
+    pub post_to_children: LookupMap<PostId, Vec<PostId>>,
+    pub label_to_posts: UnorderedMap<String, HashSet<PostId>>,
+    pub access_control: AccessControl,
+    pub authors: UnorderedMap<AccountId, HashSet<PostId>>,
+    pub communities: UnorderedMap<String, OldCommunityV1>,
+    pub featured_communities: Vec<FeaturedCommunity>,
+}
+
+// From OldContractV5 to Contract
+#[near_bindgen]
+impl Contract {
+    fn unsafe_multiple_telegrams() {
+        let OldContractV5 {
+            posts,
+            post_to_parent,
+            post_to_children,
+            label_to_posts,
+            access_control,
+            authors,
+            communities,
+            featured_communities,
+        } = env::state_read().unwrap();
+
+        let mut communities_new = UnorderedMap::new(StorageKey::Communities);
+        for (k, v) in communities.iter() {
+            let community_new = &v.into();
+            communities_new.insert(&k, community_new);
+        }
+
+        env::state_write(&Contract {
+            posts,
+            post_to_parent,
+            post_to_children,
+            label_to_posts,
+            access_control,
+            authors,
+            communities: communities_new,
+            featured_communities,
+        });
+    }
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub(crate) enum StateVersion {
     V1,
@@ -176,6 +223,7 @@ pub(crate) enum StateVersion {
     V3 { done: bool, migrated_count: u64 },
     V4,
     V5,
+    V6,
 }
 
 const VERSION_KEY: &[u8] = b"VERSION";
@@ -245,6 +293,10 @@ impl Contract {
             StateVersion::V4 => {
                 Contract::unsafe_add_featured_communities();
                 state_version_write(&StateVersion::V5);
+            }
+            StateVersion::V5 => {
+                Contract::unsafe_multiple_telegrams();
+                state_version_write(&StateVersion::V6);
             }
             _ => {
                 return Contract::migration_done();


### PR DESCRIPTION
As part of https://github.com/near/neardevhub-widgets/issues/157

Tested migration on testnet with two communties, one with telegram handle and one without. Estimated gas should be enough for mainnet migration