### PR TITLE
feat: allow moderators to call permission functions

### DIFF
--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -46,7 +46,13 @@ impl Contract {
     }
 
     pub fn add_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        near_sdk::assert_self();
+        let moderators = self.access_control.members_list.get_moderators();
+        if !env::predecessor_account_id().eq(&env::current_account_id())
+            && !moderators.contains(&Member::Account(env::current_account_id().clone()))
+        {
+            panic!("Only moderators can add members");
+        }
+
         self.access_control.members_list.add_member(member, metadata)
     }
 

--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -32,12 +32,16 @@ impl Contract {
     }
 
     pub fn set_restricted_rules(&mut self, rules: RulesList) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can set restricted rules");
+        }
         self.access_control.rules_list.set_restricted(rules)
     }
 
     pub fn unset_restricted_rules(&mut self, rules: Vec<Rule>) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can unset restricted rules");
+        }
         self.access_control.rules_list.unset_restricted(rules)
     }
 
@@ -46,23 +50,23 @@ impl Contract {
     }
 
     pub fn add_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        let moderators = self.access_control.members_list.get_moderators();
-        if !env::predecessor_account_id().eq(&env::current_account_id())
-            && !moderators.contains(&Member::Account(env::current_account_id().clone()))
-        {
-            panic!("Only moderators can add members");
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can add members");
         }
-
         self.access_control.members_list.add_member(member, metadata)
     }
 
     pub fn remove_member(&mut self, member: &Member) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can remove members");
+        }
         self.access_control.members_list.remove_member(member)
     }
 
     pub fn edit_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can edit members");
+        }
         self.access_control.members_list.edit_member(member, metadata)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,16 @@ impl Contract {
         res
     }
 
+    pub fn is_allowed_to_moderate(&self) -> bool {
+      let moderators = self.access_control.members_list.get_moderators();
+      if !env::predecessor_account_id().eq(&env::current_account_id())
+          && !moderators.contains(&Member::Account(env::current_account_id().clone()))
+      {
+          return false;
+      }
+      true
+    }
+
     pub fn is_allowed_to_edit(&self, post_id: PostId, editor: Option<AccountId>) -> bool {
         near_sdk::log!("is_allowed_to_edit");
         let post: Post = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,13 +215,9 @@ impl Contract {
     }
 
     pub fn is_allowed_to_moderate(&self) -> bool {
-      let moderators = self.access_control.members_list.get_moderators();
-      if !env::predecessor_account_id().eq(&env::current_account_id())
-          && !moderators.contains(&Member::Account(env::current_account_id().clone()))
-      {
-          return false;
-      }
-      true
+        let moderators = self.access_control.members_list.get_moderators();
+        env::predecessor_account_id() == env::current_account_id()
+            || moderators.contains(&Member::Account(env::current_account_id()))
     }
 
     pub fn is_allowed_to_edit(&self, post_id: PostId, editor: Option<AccountId>) -> bool {


### PR DESCRIPTION
_Resolves #129_

To meet the acceptance criteria of issue https://github.com/near/neardevhub-widgets/issues/129, I made edits to the following functions to enable both moderators and the contract owner to call them.
- [x] Moderators can add and remove restricted labels
set_restricted_rules
unset_restricted_rules
- [x] Moderators can create and delete teams
add_members
edit_members
remove_members
- [x] Moderators can add member and remove member from a team
add_members
edit_members
- [x] Moderators can specify which team can do with which restricted label
edit_members