### PR TITLE
Feature/159 basic moderation

### DIFF
--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -46,7 +46,13 @@ impl Contract {
     }
 
     pub fn add_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        near_sdk::assert_self();
+        let moderators = self.access_control.members_list.get_moderators();
+        if !env::predecessor_account_id().eq(&env::current_account_id())
+            && !moderators.contains(&Member::Account(env::current_account_id().clone()))
+        {
+            panic!("Only moderators can add members");
+        }
+
         self.access_control.members_list.add_member(member, metadata)
     }
 

--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -32,12 +32,16 @@ impl Contract {
     }
 
     pub fn set_restricted_rules(&mut self, rules: RulesList) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can set restricted rules");
+        }
         self.access_control.rules_list.set_restricted(rules)
     }
 
     pub fn unset_restricted_rules(&mut self, rules: Vec<Rule>) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can unset restricted rules");
+        }
         self.access_control.rules_list.unset_restricted(rules)
     }
 
@@ -46,23 +50,23 @@ impl Contract {
     }
 
     pub fn add_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        let moderators = self.access_control.members_list.get_moderators();
-        if !env::predecessor_account_id().eq(&env::current_account_id())
-            && !moderators.contains(&Member::Account(env::current_account_id().clone()))
-        {
-            panic!("Only moderators can add members");
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can add members");
         }
-
         self.access_control.members_list.add_member(member, metadata)
     }
 
     pub fn remove_member(&mut self, member: &Member) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can remove members");
+        }
         self.access_control.members_list.remove_member(member)
     }
 
     pub fn edit_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        near_sdk::assert_self();
+        if !self.is_allowed_to_moderate() {
+            panic!("Only the admin and moderators can edit members");
+        }
         self.access_control.members_list.edit_member(member, metadata)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,16 @@ impl Contract {
         res
     }
 
+    pub fn is_allowed_to_moderate(&self) -> bool {
+      let moderators = self.access_control.members_list.get_moderators();
+      if !env::predecessor_account_id().eq(&env::current_account_id())
+          && !moderators.contains(&Member::Account(env::current_account_id().clone()))
+      {
+          return false;
+      }
+      true
+    }
+
     pub fn is_allowed_to_edit(&self, post_id: PostId, editor: Option<AccountId>) -> bool {
         near_sdk::log!("is_allowed_to_edit");
         let post: Post = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,11 @@ impl Contract {
         if self.communities.get(&handle).is_some() {
             panic!("Community already exists");
         }
+        let existing_tags: Vec<String> = self.communities.values().map(|c| c.tag).collect();
+        if existing_tags.contains(&community.tag) {
+            panic!("Community tag already in-use");
+        }
+
         community.validate();
         community.set_default_admin();
         self.communities.insert(&handle, &community);


### PR DESCRIPTION
_Resolves 159_


**Acceptance Criteria**
- [ ] Community admins should have the ability to remove the designated community tag from any posts. When a tag is removed, the post will no longer show in the community feed.
- [x] Contract
- [ ] Test
- [ ] When any user creates a new community page, they should not be able to add en existing community tag to prevent abuse.
- [x] Contract
- [ ] Test
 - [ ] Community admins should have the ability to pin up to 2 posts. When they pin the post, it will appear at the top of the feed and indicate that it is pinned.
 - [x] Contract
 - [ ] Test