### PR TITLE
fix: Fixed parsing of ANY permission rule (it did not work at all before)

### DIFF
--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -23,12 +23,12 @@ impl Contract {
         &self.access_control
     }
 
-    pub fn is_restricted_label(&self, label: &String) -> bool {
-        self.access_control.rules_list.is_restricted(label)
+    pub fn is_restricted_label(&self, label: String) -> bool {
+        self.access_control.rules_list.is_restricted(&label)
     }
 
     pub fn find_restricted_labels(&self, labels: Vec<String>) -> HashSet<String> {
-        self.access_control.rules_list.find_restricted(labels)
+        self.access_control.rules_list.find_restricted(&labels)
     }
 
     pub fn set_restricted_rules(&mut self, rules: RulesList) {


### PR DESCRIPTION
Without this fix ANY rule was impossible to construct, so even though `team:moderators` has "any" permission, it just did not work. I also changed the ANY string to be `*`.