### PR TITLE
fix(ci): Use 200 TGas for `unsafe_self_upgrade` as we recently changed the required amount of gas for deployment itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.3.1/near-cli-rs-v0.3.1-installer.sh | sh
     - name: Deploy contract
       run: |
-        output=$(near contract call-function as-transaction "$NEAR_GIGSBOARD_ACCOUNT_ID" unsafe_self_upgrade file-args ./res/devgovgigs.wasm prepaid-gas '100 TeraGas' attached-deposit '0 NEAR' sign-as "$NEAR_GIGSBOARD_ACCOUNT_ID" network-config "$NEAR_NETWORK_CONNECTION" sign-with-plaintext-private-key --signer-public-key "$NEAR_GIGSBOARD_ACCOUNT_PUBLIC_KEY" --signer-private-key "$NEAR_GIGSBOARD_ACCOUNT_PRIVATE_KEY" send)
+        output=$(near contract call-function as-transaction "$NEAR_GIGSBOARD_ACCOUNT_ID" unsafe_self_upgrade file-args ./res/devgovgigs.wasm prepaid-gas '200 TeraGas' attached-deposit '0 NEAR' sign-as "$NEAR_GIGSBOARD_ACCOUNT_ID" network-config "$NEAR_NETWORK_CONNECTION" sign-with-plaintext-private-key --signer-public-key "$NEAR_GIGSBOARD_ACCOUNT_PUBLIC_KEY" --signer-private-key "$NEAR_GIGSBOARD_ACCOUNT_PRIVATE_KEY" send)
         while [[ ! "$output" == *"Migration done."* ]]; do
           echo "$output"
           sleep 5


### PR DESCRIPTION
This is a follow up to #53