### PR TITLE
fix: removed is_allowed_to_moderate and use has_moderator

### DIFF
--- a/src/access_control/mod.rs
+++ b/src/access_control/mod.rs
@@ -32,14 +32,18 @@ impl Contract {
     }
 
     pub fn set_restricted_rules(&mut self, rules: RulesList) {
-        if !self.is_allowed_to_moderate() {
+        if !self.has_moderator(env::predecessor_account_id())
+            && env::predecessor_account_id() != env::current_account_id()
+        {
             panic!("Only the admin and moderators can set restricted rules");
         }
         self.access_control.rules_list.set_restricted(rules)
     }
 
     pub fn unset_restricted_rules(&mut self, rules: Vec<Rule>) {
-        if !self.is_allowed_to_moderate() {
+        if !self.has_moderator(env::predecessor_account_id())
+            && env::predecessor_account_id() != env::current_account_id()
+        {
             panic!("Only the admin and moderators can unset restricted rules");
         }
         self.access_control.rules_list.unset_restricted(rules)
@@ -50,21 +54,27 @@ impl Contract {
     }
 
     pub fn add_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        if !self.is_allowed_to_moderate() {
+        if !self.has_moderator(env::predecessor_account_id())
+            && env::predecessor_account_id() != env::current_account_id()
+        {
             panic!("Only the admin and moderators can add members");
         }
         self.access_control.members_list.add_member(member, metadata)
     }
 
     pub fn remove_member(&mut self, member: &Member) {
-        if !self.is_allowed_to_moderate() {
+        if !self.has_moderator(env::predecessor_account_id())
+            && env::predecessor_account_id() != env::current_account_id()
+        {
             panic!("Only the admin and moderators can remove members");
         }
         self.access_control.members_list.remove_member(member)
     }
 
     pub fn edit_member(&mut self, member: Member, metadata: VersionedMemberMetadata) {
-        if !self.is_allowed_to_moderate() {
+        if !self.has_moderator(env::predecessor_account_id())
+            && env::predecessor_account_id() != env::current_account_id()
+        {
             panic!("Only the admin and moderators can edit members");
         }
         self.access_control.members_list.edit_member(member, metadata)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,12 +216,6 @@ impl Contract {
         res
     }
 
-    pub fn is_allowed_to_moderate(&self) -> bool {
-        let moderators = self.access_control.members_list.get_moderators();
-        env::predecessor_account_id() == env::current_account_id()
-            || moderators.contains(&Member::Account(env::current_account_id()))
-    }
-
     pub fn is_allowed_to_edit(&self, post_id: PostId, editor: Option<AccountId>) -> bool {
         near_sdk::log!("is_allowed_to_edit");
         let post: Post = self


### PR DESCRIPTION
## Problem:
Both @carina-akaia and I created a function to check if a moderator has access to call a function. Carina named it *has_moderator*, because self is a Contract, which makes it more semantically clear:
`contract.has_moderator(account_id)`

## Solution:
I refactored the code and removed the function *is_allowed_to_moderate* and replaced with *has_moderator*.