### PR TITLE
fix: Renamed 'Near' to 'NEAR' in the SponsorshipToken to align with the front-end and the NEAR branding

### DIFF
--- a/src/post/sponsorship.rs
+++ b/src/post/sponsorship.rs
@@ -5,25 +5,13 @@ use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{AccountId, Balance, Timestamp};
 use std::collections::HashSet;
-use std::str::FromStr;
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[serde(crate = "near_sdk::serde")]
 pub enum SponsorshipToken {
-    Near,
+    NEAR,
     NEP141 { address: AccountId },
     USD,
-}
-
-impl FromStr for SponsorshipToken {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "near" => Ok(Self::Near),
-            _ => Ok(Self::NEP141 { address: s.to_string() }),
-        }
-    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]

--- a/tests/snapshots/migration__deploy_contract_self_upgrade-4.snap
+++ b/tests/snapshots/migration__deploy_contract_self_upgrade-4.snap
@@ -36,7 +36,7 @@ expression: get_attestation_sponsorship_posts
       "sponsorship_version": "V1",
       "name": "Contributor fellowship",
       "description": "Funding approved",
-      "sponsorship_token": "Near",
+      "sponsorship_token": "NEAR",
       "amount": "1000",
       "supervisor": "john.near"
     },


### PR DESCRIPTION
This was originally reported by Maria.