### PR TITLE
Fix: workspaces test fix for Sponsorship token, change Near to NEAR

### DIFF
--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -99,7 +99,7 @@ async fn test_deploy_contract_self_upgrade() -> anyhow::Result<()> {
                 "name": "Contributor fellowship",
                 "description": "Funding approved",
                 "amount": "1000",
-                "sponsorship_token": "Near",
+                "sponsorship_token": "NEAR",
                 "supervisor": "john.near",
                 "sponsorship_version": "V1",
                 "post_type": "Sponsorship"


### PR DESCRIPTION
After the merge of the following commit - https://github.com/near/neardevhub-contract/commit/b47efe2a5f19fefc61184dcafa76806b21427cf1

Workspaces test failed due to unknown sponsorship token error because of the token value Near, changing it to NEAR in the test fixes the issue. 