### PR TITLE
clean up old community fields and migrates

### DIFF
--- a/src/community/mod.rs
+++ b/src/community/mod.rs
@@ -107,16 +107,9 @@ pub struct Community {
     pub banner_url: String,
     pub bio_markdown: Option<String>,
     pub github_handle: Option<String>,
-    pub telegram_handle: Vec<String>,
+    pub telegram_handle: Option<String>,
     pub twitter_handle: Option<String>,
     pub website_url: Option<String>,
-    /// JSON string of github board configuration
-    pub github: Option<String>,
-    /// JSON string of kanban board configuration
-    pub board: Option<String>,
-    pub wiki1: Option<WikiPage>,
-    pub wiki2: Option<WikiPage>,
-    pub features: CommunityFeatureFlags,
     pub addons: Vec<CommunityAddOn>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,20 +344,9 @@ impl Contract {
             banner_url: inputs.banner_url,
             bio_markdown: inputs.bio_markdown,
             github_handle: None,
-            telegram_handle: vec![],
+            telegram_handle: None,
             twitter_handle: None,
             website_url: None,
-            github: None,
-            board: None,
-            wiki1: None,
-            wiki2: None,
-
-            features: CommunityFeatureFlags {
-                telegram: true,
-                github: true,
-                board: true,
-                wiki: true,
-            },
             addons: vec![],
         };
 
@@ -532,56 +521,6 @@ impl Contract {
             self.communities.insert(&community.handle, &community);
         }
     }
-
-    pub fn update_community_feature_flags(
-        &mut self,
-        handle: CommunityHandle,
-        features: CommunityFeatureFlags,
-    ) {
-        let mut community = self
-            .get_editable_community(&handle)
-            .expect("Only community admins and hub moderators can configure communities");
-
-        community.features = features;
-        self.communities.insert(&handle, &community);
-    }
-
-    pub fn update_community_github(&mut self, handle: CommunityHandle, github: Option<String>) {
-        let mut community = self
-            .get_editable_community(&handle)
-            .expect("Only community admins and hub moderators can configure boards");
-
-        community.github = github;
-        self.communities.insert(&handle, &community);
-    }
-
-    pub fn update_community_board(&mut self, handle: CommunityHandle, board: Option<String>) {
-        let mut community = self
-            .get_editable_community(&handle)
-            .expect("Only community admins and hub moderators can configure boards");
-
-        community.board = board;
-        self.communities.insert(&handle, &community);
-    }
-
-    pub fn update_community_wiki1(&mut self, handle: CommunityHandle, wiki1: Option<WikiPage>) {
-        let mut community = self
-            .get_editable_community(&handle)
-            .expect("Only community admins and hub moderators can edit wiki");
-
-        community.wiki1 = wiki1;
-        self.communities.insert(&handle, &community);
-    }
-
-    pub fn update_community_wiki2(&mut self, handle: CommunityHandle, wiki2: Option<WikiPage>) {
-        let mut community = self
-            .get_editable_community(&handle)
-            .expect("Only community admins and hub moderators can edit wiki");
-
-        community.wiki2 = wiki2;
-        self.communities.insert(&handle, &community);
-    }
-
     pub fn delete_community(&mut self, handle: CommunityHandle) {
         require!(
             self.has_moderator(env::predecessor_account_id()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Contract {
 impl Contract {
     #[init]
     pub fn new() -> Self {
-        migrations::state_version_write(&migrations::StateVersion::V8);
+        migrations::state_version_write(&migrations::StateVersion::V9);
 
         let mut contract = Self {
             posts: Vector::new(StorageKey::Posts),

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -534,7 +534,7 @@ impl Contract {
                         telegram_handle: community.telegram_handle.first().cloned(),
                         twitter_handle: community.twitter_handle,
                         website_url: community.website_url,
-                        addons: Vec::new(),
+                        addons: community.addons,
                     },
                 )
             })

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -501,6 +501,97 @@ pub struct ContractV8 {
     pub available_addons: UnorderedMap<AddOnId, AddOn>,
 }
 
+// From ContractV8 to ContractV9
+#[near_bindgen]
+impl Contract {
+    fn unsafe_clean_up_community() {
+        let ContractV8 {
+            posts,
+            post_to_parent,
+            post_to_children,
+            label_to_posts,
+            access_control,
+            authors,
+            mut communities,
+            featured_communities,
+            available_addons,
+        } = env::state_read().unwrap();
+        let migrated_communities: Vec<(String, CommunityV5)> = communities
+            .iter()
+            .map(|(community_handle, community)| {
+                (
+                    community_handle,
+                    CommunityV5 {
+                        admins: community.admins,
+                        handle: community.handle,
+                        name: community.name,
+                        tag: community.tag,
+                        description: community.description,
+                        logo_url: community.logo_url,
+                        banner_url: community.banner_url,
+                        bio_markdown: community.bio_markdown,
+                        github_handle: community.github_handle,
+                        telegram_handle: community.telegram_handle.first().cloned(),
+                        twitter_handle: community.twitter_handle,
+                        website_url: community.website_url,
+                        addons: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+
+        communities.clear();
+
+        let mut communities_new = UnorderedMap::new(StorageKey::Communities);
+
+        for (k, v) in migrated_communities {
+            communities_new.insert(&k, &v);
+        }
+
+        env::state_write(&ContractV9 {
+            posts,
+            post_to_parent,
+            post_to_children,
+            label_to_posts,
+            access_control,
+            authors,
+            communities: communities_new,
+            featured_communities,
+            available_addons,
+        });
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct CommunityV5 {
+    pub admins: Vec<AccountId>,
+    pub handle: CommunityHandle,
+    pub name: String,
+    pub tag: String,
+    pub description: String,
+    pub logo_url: String,
+    pub banner_url: String,
+    pub bio_markdown: Option<String>,
+    pub github_handle: Option<String>,
+    pub telegram_handle: Option<String>,
+    pub twitter_handle: Option<String>,
+    pub website_url: Option<String>,
+    pub addons: Vec<CommunityAddOn>,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
+pub struct ContractV9 {
+    pub posts: Vector<VersionedPost>,
+    pub post_to_parent: LookupMap<PostId, PostId>,
+    pub post_to_children: LookupMap<PostId, Vec<PostId>>,
+    pub label_to_posts: UnorderedMap<String, HashSet<PostId>>,
+    pub access_control: AccessControl,
+    pub authors: UnorderedMap<AccountId, HashSet<PostId>>,
+    pub communities: UnorderedMap<String, CommunityV5>,
+    pub featured_communities: Vec<FeaturedCommunity>,
+    pub available_addons: UnorderedMap<AddOnId, AddOn>,
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub(crate) enum StateVersion {
     V1,
@@ -511,6 +602,7 @@ pub(crate) enum StateVersion {
     V6,
     V7,
     V8,
+    V9,
 }
 
 const VERSION_KEY: &[u8] = b"VERSION";
@@ -592,6 +684,10 @@ impl Contract {
             StateVersion::V7 => {
                 Contract::unsafe_add_community_addons();
                 state_version_write(&StateVersion::V8);
+            }
+            StateVersion::V8 => {
+                Contract::unsafe_clean_up_community();
+                state_version_write(&StateVersion::V9);
             }
             _ => {
                 return Contract::migration_done();

--- a/tests/snapshots/migration__deploy_contract_self_upgrade-8.snap
+++ b/tests/snapshots/migration__deploy_contract_self_upgrade-8.snap
@@ -14,18 +14,8 @@ expression: get_community
   "banner_url": "https://ipfs.near.social/ipfs/bafkreic4xgorjt6ha5z4s5e3hscjqrowe5ahd7hlfc5p4hb6kdfp6prgy4",
   "bio_markdown": "This is a sample text about your community.\nYou can change it on the community configuration page.",
   "github_handle": null,
-  "telegram_handle": [],
+  "telegram_handle": null,
   "twitter_handle": null,
   "website_url": null,
-  "github": null,
-  "board": null,
-  "wiki1": null,
-  "wiki2": null,
-  "features": {
-    "telegram": true,
-    "github": true,
-    "board": true,
-    "wiki": true
-  },
   "addons": []
 }


### PR DESCRIPTION
_Resolves #74_ and _Resolves #76_ and unblocks [#544](https://github.com/near/neardevhub-widgets/issues/544)

Since issue #74, #75 and #76 need a migration, I'm gonna tackle them together to get it done in one go. But just to be on the safe side, I'll create separate pull requests in case any issues pop up later on. 

Also still need to thoroughly search if there are more things to clean up.

UPDATE:

Because 75 is still in progress I will open this PR for review and write another seperate migration for PR #78 tomorrow.


To link this PR to issue 544 on the board i will add this:
_Resolves [#544](https://github.com/near/neardevhub-widgets/issues/544)_