### PR TITLE
feature: test for state version in integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,3 @@ jobs:
       - name: Unit tests
         run: |
           cargo test
-
-  teststateversion:
-    name: Test state version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Run test script
-        run: |
-          chmod +x test.sh
-          ./test.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   rununittest:
     name: Unit tests
@@ -22,3 +22,14 @@ jobs:
       - name: Unit tests
         run: |
           cargo test
+
+  teststateversion:
+    name: Test state version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run test script
+        run: |
+          chmod +x test.sh
+          ./test.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,6 +571,7 @@ mod tests {
     use crate::access_control::members::{ActionType, Member, MemberMetadata};
     use crate::access_control::rules::Rule;
     use crate::community::{AddOn, Community, CommunityAddOn, CommunityInputs};
+    use crate::migrations::{self, StateVersion};
     use crate::post::PostBody;
     use near_sdk::store::vec;
     use near_sdk::test_utils::{get_created_receipts, VMContextBuilder};
@@ -603,6 +604,39 @@ mod tests {
             .predecessor_account_id(signer.try_into().unwrap())
             .is_view(is_view)
             .build()
+    }
+
+    #[test]
+    pub fn test_new_state_version() {
+        let context = get_context(false);
+
+        // Use testing environment
+        testing_env!(context);
+
+        // Deploy the contract
+        let mut contract = Contract::new();
+
+        // Call the needs_migration function to check if migration is needed
+        let state_version = migrations::state_version_read();
+
+        match state_version {
+            StateVersion::V1 => {}
+            StateVersion::V2 => {}
+            StateVersion::V3 { done: false, migrated_count } => {}
+            StateVersion::V3 { done: true, migrated_count: _ } => {}
+            StateVersion::V4 => {}
+            StateVersion::V5 => {}
+            StateVersion::V6 => {}
+            StateVersion::V7 => {}
+            StateVersion::V8 => {}
+            StateVersion::V9 => {}
+            // @petersalomonsen Would need to upgrade this
+            _ => {
+                panic!("State version in new is not the latest version");
+            }
+        }
+        // And this..
+        assert_eq!(state_version, StateVersion::V9);
     }
 
     #[test]

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -592,7 +592,7 @@ pub struct ContractV9 {
     pub available_addons: UnorderedMap<AddOnId, AddOn>,
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Debug)]
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub(crate) enum StateVersion {
     V1,
     V2,
@@ -607,7 +607,7 @@ pub(crate) enum StateVersion {
 
 const VERSION_KEY: &[u8] = b"VERSION";
 
-fn state_version_read() -> StateVersion {
+pub(crate) fn state_version_read() -> StateVersion {
     env::storage_read(VERSION_KEY)
         .map(|data| {
             StateVersion::try_from_slice(&data).expect("Cannot deserialize the contract state.")

--- a/test.sh
+++ b/test.sh
@@ -20,19 +20,3 @@ contract=i.zxcvn.testnet
 #near call contract.devhubopen.testnet unsafe_self_upgrade --accountId contract.devhubopen.testnet --args $(base64 < res/devgovgigs.wasm ) --base64 --gas 300000000000000
 
 # near call $contract unsafe_migrate --accountId $contract --gas 300000000000000
-
-LIB_NEW="src/lib.rs"
-STATE_VERSION_ENUM="src/migrations.rs"
-
-# Extract the latest state version from migrations
-latest_version=$(grep -o 'StateVersion::V[0-9]*' "$STATE_VERSION_ENUM" | tail -n 1)
-
-# Extract the version mentioned in new
-new_function_version=$(awk '/pub fn new/ {getline; print}' "$LIB_NEW" | grep -o 'StateVersion::V[0-9]*')
-
-if [ "$latest_version" = "$new_function_version" ]; then
-    exit 0
-else
-    echo "Test failed: Latest state version does not match the version in the new function."
-    exit 1
-fi

--- a/test.sh
+++ b/test.sh
@@ -20,3 +20,19 @@ contract=i.zxcvn.testnet
 #near call contract.devhubopen.testnet unsafe_self_upgrade --accountId contract.devhubopen.testnet --args $(base64 < res/devgovgigs.wasm ) --base64 --gas 300000000000000
 
 # near call $contract unsafe_migrate --accountId $contract --gas 300000000000000
+
+LIB_NEW="src/lib.rs"
+STATE_VERSION_ENUM="src/migrations.rs"
+
+# Extract the latest state version from migrations
+latest_version=$(grep -o 'StateVersion::V[0-9]*' "$STATE_VERSION_ENUM" | tail -n 1)
+
+# Extract the version mentioned in new
+new_function_version=$(awk '/pub fn new/ {getline; print}' "$LIB_NEW" | grep -o 'StateVersion::V[0-9]*')
+
+if [ "$latest_version" = "$new_function_version" ]; then
+    exit 0
+else
+    echo "Test failed: Latest state version does not match the version in the new function."
+    exit 1
+fi

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -283,56 +283,5 @@ async fn test_deploy_contract_self_upgrade() -> anyhow::Result<()> {
         .json()?;
 
     insta::assert_json_snapshot!(get_community);
-    test_state_version().await?;
-    Ok(())
-}
-
-// async fn test_close_account_non_empty_balance(
-//     user_with_funds: &Account,
-//     contract: &Contract,
-//     worker: &Worker<Sandbox>,
-// ) -> anyhow::Result<()> {
-//     let contract = init_contracts().await?;
-
-//     match user_with_funds
-//         .call(&worker, contract.id(), "storage_unregister")
-//         .args_json(serde_json::json!({}))?
-//         .deposit(1)
-//         .transact()
-//         .await
-//     {
-//         Ok(_result) => {
-//             panic!("storage_unregister worked despite account being funded")
-//         }
-//         Err(e) => {
-//             let e_string = e.to_string();
-//             if !e_string
-//                 .contains("Can't unregister the account with the positive balance without force")
-//             {
-//                 panic!("storage_unregister with balance displays unexpected error message")
-//             }
-//             println!("      Passed ✅ test_close_account_non_empty_balance");
-//         }
-//     }
-//     Ok(())
-// }
-// #[should_panic]
-async fn test_state_version() -> anyhow::Result<()> {
-    let contract = init_contracts().await?;
-
-    let deposit_amount = near_units::parse_near!("0.1");
-
-    // Call self upgrade with current branch code
-    // compile the current code
-    let wasm = near_workspaces::compile_project("./").await?;
-
-    let mut contract_upgrade_result =
-        contract.call("unsafe_self_upgrade").args(wasm).max_gas().transact().await?;
-
-    while contract_upgrade_result.json::<String>()? == "needs-migration" {
-        contract_upgrade_result =
-            contract.call("unsafe_migrate").args_json(json!({})).max_gas().transact().await?;
-    }
-
     Ok(())
 }


### PR DESCRIPTION
Resolves 71

I wasn't sure how to test the correct version using rust, so I suggest this approach. However, if there's a more effective way to test it, please let me know.

Also this is not perfect since it has the flaw that it depends the `migrations.rs` to be chronically correct.