### PR TITLE
social media links using web4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "devhub_common",
+ "html-escape",
  "insta",
  "near-contract-standards",
  "near-sdk",
@@ -1430,6 +1431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -4159,6 +4169,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ near-sdk = "5.1.0"
 near-contract-standards = "5.1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 devhub_common = { path = "./devhub_common" }
+html-escape = "0.2.13"
 
 [dev-dependencies]
 near-sdk = { version = "5.1.0", features = ["unit-testing"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod community;
 pub mod debug;
 pub mod migrations;
 mod notify;
+pub mod web4;
 pub mod post;
 pub mod proposal;
 mod repost;
@@ -24,6 +25,7 @@ use near_sdk::collections::{LookupMap, UnorderedMap, Vector};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::{json, Number, Value};
 use near_sdk::{env, near, require, AccountId, NearSchema, PanicOnDefault, Promise};
+use web4::types::{Web4Request,Web4Response};
 
 use std::collections::HashSet;
 use std::convert::TryInto;
@@ -980,6 +982,10 @@ impl Contract {
         let moderators = self.access_control.members_list.get_moderators();
         moderators.contains(&Member::Account(account_id))
     }
+
+    pub fn web4_get(&self, request: Web4Request) -> Web4Response {
+        web4::handler::web4_get(request)
+    }
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, NearSchema)]
@@ -991,7 +997,9 @@ pub struct BlockHeightCallbackRetValue {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use crate::community::AddOn;
+
     use crate::{PostBody, ProposalBodyV0, VersionedProposalBody};
+
     use near_sdk::test_utils::{get_created_receipts, VMContextBuilder};
     use near_sdk::{testing_env, VMContext};
     use serde_json::json;
@@ -1155,4 +1163,5 @@ mod tests {
 
         assert_eq!(addons[0].title, "Telegram AddOn".to_owned());
     }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@ pub mod community;
 pub mod debug;
 pub mod migrations;
 mod notify;
-pub mod web4;
 pub mod post;
 pub mod proposal;
 mod repost;
 pub mod stats;
 pub mod str_serializers;
+pub mod web4;
 
 use crate::access_control::members::ActionType;
 use crate::access_control::members::Member;
@@ -25,7 +25,7 @@ use near_sdk::collections::{LookupMap, UnorderedMap, Vector};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::{json, Number, Value};
 use near_sdk::{env, near, require, AccountId, NearSchema, PanicOnDefault, Promise};
-use web4::types::{Web4Request,Web4Response};
+use web4::types::{Web4Request, Web4Response};
 
 use std::collections::HashSet;
 use std::convert::TryInto;
@@ -984,7 +984,7 @@ impl Contract {
     }
 
     pub fn web4_get(&self, request: Web4Request) -> Web4Response {
-        web4::handler::web4_get(request)
+        web4::handler::web4_get(self, request)
     }
 }
 
@@ -1163,5 +1163,4 @@ mod tests {
 
         assert_eq!(addons[0].title, "Telegram AddOn".to_owned());
     }
-
 }

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -83,15 +83,19 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/runtime.25b143da327a5371509f.bundle.js"></script>
 </head>
 <body>
-    <div class="container">
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <div class="navbar-brand"><img src="https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near" style="width: 64px" /></div>
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item"><a href="https://near.org/{redirect_path}" class="nav-link">near.org</a></li>
-                <li class="nav-item"><a href="https://near.social/{redirect_path}" class="nav-link">near.social</a></li>
-            </ul>
-        </nav>
+<nav class="navbar navbar-expand-sm navbar-light bg-light" style="display: flex; flex-wrap: nowrap; padding-left: 5px; padding-right: 5px;">
+    <a class="navbar-brand" href="/""><img src="https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near" style="width: 64px" /></a>
+    <p class="nav-text" style="flex-grow: 1"></p>
+    <p class="nav-text">Choose your gateway</p>
+    <div class="navbar-nav">
+        <a href="https://near.org/{redirect_path}" class="btn btn-light btn-sm">
+            <img src="https://near.org/_next/static/media/near-logo.1416a213.svg" />
+        </a>
+        <a href="https://near.social/{redirect_path}" class="btn btn-dark btn-sm">
+            <img src="https://ipfs.web4.near.page/ipfs/bafybeieugu57nj5c6jhgtozvbyj6am3lh5baeb4uvjh3re26ihp7sjmnra/nearsocial.svg" />
+        </a>
     </div>
+</nav>
     <near-social-viewer src="devhub.near/widget/app" initialProps='{initial_props_json}'></near-social-viewer>
 </body>
 </html>"#,

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -43,9 +43,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
             }
             "proposal" => {
                 let id_string = path_parts[2];
-                let id_option = id_string.parse::<u32>();
-                if id_option.is_ok() {
-                    let id = id_option.unwrap();
+                if let Ok(id) = id_string.parse::<u32>() {
                     let proposal_option = contract.proposals.get(id.into());
                     if proposal_option.is_some() {
                         let proposal: Proposal = Proposal::from(proposal_option.unwrap());

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -42,8 +42,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
                 initial_props_json = json!({"page": page, "handle": handle}).to_string();
             }
             "proposal" => {
-                if path_parts.len() > 2 {
-                    let id_string = path_parts[2];
+                if let Some(id_string) = path_parts.get(2) {
                     if let Ok(id) = id_string.parse::<u32>() {
                         if let Some(versioned_proposal) = contract.proposals.get(id.into()) {
                             let proposal_body =

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -43,13 +43,10 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
             }
             "proposal" => {
                 let id_string = path_parts[2];
-                let id_option = id_string.parse::<u32>();
-                if id_option.is_ok() {
-                    let id = id_option.unwrap();
-                    let proposal_option = contract.proposals.get(id.into());
-                    if proposal_option.is_some() {
-                        let proposal: Proposal = Proposal::from(proposal_option.unwrap());
-                        let proposal_body = proposal.snapshot.body.latest_version();
+                if let Ok(id) = id_string.parse::<u32>() {
+                    if let Some(versioned_proposal) = contract.proposals.get(id.into()) {
+                        let proposal_body =
+                            Proposal::from(versioned_proposal).snapshot.body.latest_version();
                         title = html_escape::encode_text(proposal_body.name.as_str()).to_string();
                         description =
                             html_escape::encode_text(proposal_body.summary.as_str()).to_string();

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -44,9 +44,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
             "proposal" => {
                 let id_string = path_parts[2];
                 if let Ok(id) = id_string.parse::<u32>() {
-                    let proposal_option = contract.proposals.get(id.into());
-                    if proposal_option.is_some() {
-                        let proposal: Proposal = Proposal::from(proposal_option.unwrap());
+                    if let Some(proposal) = contract.proposals.get(id.into()) {
                         let proposal_body = proposal.snapshot.body.latest_version();
                         title = html_escape::encode_text(proposal_body.name.as_str()).to_string();
                         description =

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -81,18 +81,30 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     <meta name="twitter:image" content="{image}">
     <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/main.794b6347ae264789bc61.bundle.js"></script>
     <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/runtime.25b143da327a5371509f.bundle.js"></script>
+    <style>
+        @media screen and (max-width: 600px) {{
+            .gatewaylinks .nav-link {{
+                padding-top: 0px!important;
+                padding-bottom: 0px!important;
+                margin: 0px;
+            }}
+            .gatewaylinks img {{
+                height: 30px;
+            }}
+        }}
+    </style>
 </head>
 <body>
-<nav class="navbar navbar-expand-sm navbar-light bg-light" style="display: flex; flex-wrap: nowrap; padding-left: 5px; padding-right: 5px;">
-    <a class="navbar-brand" href="/""><img src="https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near" style="width: 64px" /></a>
+<nav class="navbar navbar-expand-sm navbar-light bg-dark" style="display: flex; flex-wrap: nowrap; padding-left: 5px; padding-right: 5px; height: 73px; border-bottom: rgb(0, 236, 151) solid 5px;">
+    <a class="navbar-brand" href="/""><img src="https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near" style="height: 68px" /></a>
     <p class="nav-text" style="flex-grow: 1"></p>
-    <p class="nav-text">Choose your gateway</p>
-    <div class="navbar-nav">
-        <a href="https://near.org/{redirect_path}" class="btn btn-light btn-sm">
-            <img src="https://near.org/_next/static/media/near-logo.1416a213.svg" />
+    <p class="nav-text text-light" style="margin-top: 1rem; margin-right: 1rem">Choose your gateway</p>
+    <div class="navbar-nav gatewaylinks">
+        <a href="https://near.org/{redirect_path}" class="nav-link">
+            <img src="https://ipfs.web4.near.page/ipfs/bafybeia2ptgyoz7b6oxu3k57jmiras2pgigmw7a3cp6osjog67rndmf36y/nearorg.svg" />
         </a>
-        <a href="https://near.social/{redirect_path}" class="btn btn-dark btn-sm">
-            <img src="https://ipfs.web4.near.page/ipfs/bafybeieugu57nj5c6jhgtozvbyj6am3lh5baeb4uvjh3re26ihp7sjmnra/nearsocial.svg" />
+        <a href="https://near.social/{redirect_path}" class="nav-link">
+            <img src="https://ipfs.web4.near.page/ipfs/bafybeia2ptgyoz7b6oxu3k57jmiras2pgigmw7a3cp6osjog67rndmf36y/nearsocial.svg" />
         </a>
     </div>
 </nav>

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -16,15 +16,13 @@ pub const BASE64_ENGINE: engine::GeneralPurpose =
 pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     let path_parts: Vec<&str> = request.path.split('/').collect();
 
-    let gateway = "https://near.social";
-
     let page = path_parts[1];
     let mut title: String = String::from("near/dev/hub");
     let mut description: String = String::from("The decentralized home base for NEAR builders");
     let mut image: String = String::from(
         "https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near",
     );
-    let mut redirect_url: String = String::from("https://near.social/devhub.near/widget/app");
+    let mut redirect_path: String = String::from("devhub.near/widget/app");
 
     let mut initial_props_json = json!({"page": page}).to_string();
 
@@ -40,8 +38,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
                         html_escape::encode_text(community.description.as_str()).to_string();
                     image = community.logo_url;
                 }
-                redirect_url =
-                    format!("{}/devhub.near/widget/app?page={}&handle={}", gateway, page, handle);
+                redirect_path = format!("devhub.near/widget/app?page={}&handle={}", page, handle);
                 initial_props_json = json!({"page": page, "handle": handle}).to_string();
             }
             "proposal" => {
@@ -58,8 +55,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
                             html_escape::encode_text(proposal_body.summary.as_str()).to_string();
                     }
                 }
-                redirect_url =
-                    format!("{}/devhub.near/widget/app?page={}&id={}", gateway, page, id_string);
+                redirect_path = format!("devhub.near/widget/app?page={}&id={}", page, id_string);
                 initial_props_json = json!({"page": page, "id": id_string}).to_string();
             }
             _ => {}
@@ -87,10 +83,19 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/runtime.25b143da327a5371509f.bundle.js"></script>
 </head>
 <body>
+    <div class="container">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light">
+            <div class="navbar-brand"><img src="https://i.near.social/magic/large/https://near.social/magic/img/account/devhub.near" style="width: 64px" /></div>
+            <ul class="navbar-nav mr-auto">
+                <li class="nav-item"><a href="https://near.org/{redirect_path}" class="nav-link">near.org</a></li>
+                <li class="nav-item"><a href="https://near.social/{redirect_path}" class="nav-link">near.social</a></li>
+            </ul>
+        </nav>
+    </div>
     <near-social-viewer src="devhub.near/widget/app" initialProps='{initial_props_json}'></near-social-viewer>
 </body>
 </html>"#,
-        url = redirect_url
+        url = redirect_path
     );
 
     Web4Response::Body {
@@ -110,10 +115,7 @@ mod tests {
         VersionedProposalBody,
     };
     use near_sdk::{
-        base64::Engine,
-        serde_json::json,
-        test_utils::VMContextBuilder,
-        testing_env, NearToken,
+        base64::Engine, serde_json::json, test_utils::VMContextBuilder, testing_env, NearToken,
     };
 
     #[test]
@@ -213,6 +215,7 @@ mod tests {
                     body_string.contains("<meta name=\"twitter:title\" content=\"near/dev/hub\">")
                 );
                 assert!(body_string.contains("https://near.social/devhub.near/widget/app"));
+                assert!(body_string.contains("https://near.org/devhub.near/widget/app"));
                 let expected_initial_props_string =
                     json!({"page": "community", "handle": "blablablablabla"}).to_string();
                 assert!(body_string.contains(&expected_initial_props_string));
@@ -283,6 +286,8 @@ mod tests {
                     .contains("<meta name=\"twitter:title\" content=\"The best proposal ever\">"));
                 assert!(body_string
                     .contains("https://near.social/devhub.near/widget/app?page=proposal&id=0"));
+                assert!(body_string
+                    .contains("https://near.org/devhub.near/widget/app?page=proposal&id=0"));
                 let expected_initial_props_string =
                     json!({"page": "proposal", "id": "0"}).to_string();
                 assert!(body_string.contains(&expected_initial_props_string));

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -1,18 +1,40 @@
-use near_sdk::base64::{alphabet, engine::{self, general_purpose}, Engine};
+use near_sdk::base64::{
+    alphabet,
+    engine::{self, general_purpose},
+    Engine,
+};
 
-use crate::web4::types::{Web4Request, Web4Response};
+use crate::{
+    web4::types::{Web4Request, Web4Response},
+    Contract,
+};
 
-const BASE64_ENGINE: engine::GeneralPurpose =
+pub const BASE64_ENGINE: engine::GeneralPurpose =
     engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
 
-pub fn web4_get(#[allow(unused_variables)] request: Web4Request) -> Web4Response {
+pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     let path_parts: Vec<&str> = request.path.split('/').collect();
 
-    let page = path_parts[1]; // Assuming path format is "/community/webassemblymusic"
-    let handle = path_parts[2];
+    let gateway = "https://near.social";
 
+    let page = path_parts[1];
+    let mut title: String = String::from("Title");
+    let mut description: String = String::from("Description");
+    let mut image: String = String::from("");
+    let mut redirect_url: String = gateway.to_string();
 
-    let redirect_url = format!("https://near.social/devhub.near/widget/app?page={}&handle={}", page, handle);
+    match page {
+        "community" => {
+            let handle = path_parts[2];
+            let community = contract.get_community(handle.to_string()).unwrap();
+            redirect_url =
+                format!("{}/devhub.near/widget/app?page={}&handle={}", gateway, page, handle);
+            title = community.name;
+            description = community.description;
+            image = community.logo_url;
+        }
+        _ => {}
+    }
 
     let body = format!(
         r#"<!DOCTYPE html>
@@ -21,18 +43,19 @@ pub fn web4_get(#[allow(unused_variables)] request: Web4Request) -> Web4Response
     <title>Your Website Title</title>
     <meta property="og:url" content="{url}" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Your Title Here" />
-    <meta property="og:description" content="Your description here" />
-    <meta property="og:image" content="https://example.com/image.jpg" />
+    <meta property="og:title" content="{title}" />
+    <meta property="og:description" content="{description}" />
+    <meta property="og:image" content="{image}" />
 
     <!-- Additional tags for Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Your Title Here">
-    <meta name="twitter:description" content="Your description here">
-    <meta name="twitter:image" content="https://example.com/image.jpg">
+    <meta name="twitter:title" content="{title}">
+    <meta name="twitter:description" content="{description}">
+    <meta name="twitter:image" content="{image}">
 </head>
 <body>
-    <h1>Hello, check out this link:</h1>
+    <h1>{title}</h1>
+    <p>{description}</p>
     <a href="{url}">Visit our page</a>
 </body>
 </html>"#,
@@ -47,25 +70,67 @@ pub fn web4_get(#[allow(unused_variables)] request: Web4Request) -> Web4Response
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::web4::types::Web4Response;
     use super::web4_get;
+    use crate::{
+        web4::{handler::BASE64_ENGINE, types::Web4Response},
+        CommunityInputs, Contract,
+    };
+    use near_sdk::{
+        base64::Engine, test_utils::VMContextBuilder, testing_env, NearToken, VMContext,
+    };
+
+    fn get_context_with_signer(is_view: bool, signer: String) -> VMContext {
+        VMContextBuilder::new()
+            .signer_account_id(signer.clone().try_into().unwrap())
+            .current_account_id(signer.try_into().unwrap())
+            .is_view(is_view)
+            .attached_deposit(NearToken::from_near(4))
+            .build()
+    }
+
+    fn get_context(is_view: bool) -> VMContext {
+        get_context_with_signer(is_view, "bob.near".to_string())
+    }
 
     #[test]
     pub fn test_web4() {
-        let response = web4_get(serde_json::from_value(serde_json::json!({
-            "path": "/community/webassemblymusic"
-        })).unwrap());
+        let context = get_context(false);
+        testing_env!(context);
+        let mut contract = Contract::new();
+
+        contract.create_community(CommunityInputs {
+            handle: String::from("webassemblymusic"),
+            name: String::from("WebAssembly Music"), 
+            description: String::from("Music stored forever in the NEAR blockchain"),tag: String::from("wasm"),
+            logo_url: String::from("https://ipfs.near.social/ipfs/bafybeiesrsf4fpdmlfgcnxpuxiqlgw2lk3bietdt25mvumrjk5yhf2c54e"),
+            banner_url: String::from("https://ipfs.near.social/ipfs/bafybeihsid3qgrb2dd4adsd4kuwe3pondtjr3u27ru6e2mbvabvm4rocru"),
+            bio_markdown: Some(String::from("Music stored forever in the NEAR blockchain"))
+        });
+
+        let response = web4_get(
+            &contract,
+            serde_json::from_value(serde_json::json!({
+                "path": "/community/webassemblymusic"
+            }))
+            .unwrap(),
+        );
         match response {
             Web4Response::Body { content_type, body } => {
-                println!("Content Type: {}", content_type);
-                println!("Body: {}", body);
-            },
+                assert_eq!("text/html; charset=UTF-8", content_type);
+
+                let body_string = String::from_utf8(BASE64_ENGINE.decode(body).unwrap()).unwrap();
+                println!("Body: {:?}", body_string);
+                assert!(body_string.contains("<meta property=\"og:description\" content=\"Music stored forever in the NEAR blockchain\" />"));
+                assert!(body_string
+                    .contains("<meta name=\"twitter:title\" content=\"WebAssembly Music\">"));
+                assert!(body_string.contains("https://near.social/devhub.near/widget/app?page=community&handle=webassemblymusic"));
+            }
             Web4Response::BodyUrl { body_url } => {
-                println!("Body is located at URL: {}", body_url);
-            },
+                panic!("Should not return BodyUrl");
+            }
             Web4Response::PreloadUrls { preload_urls } => {
-                println!("Preloaded URLs: {:?}", preload_urls);
-            },
+                panic!("Should not be preload urls");
+            }
         }
     }
 }

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -1,0 +1,71 @@
+use near_sdk::base64::{alphabet, engine::{self, general_purpose}, Engine};
+
+use crate::web4::types::{Web4Request, Web4Response};
+
+const BASE64_ENGINE: engine::GeneralPurpose =
+    engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
+
+pub fn web4_get(#[allow(unused_variables)] request: Web4Request) -> Web4Response {
+    let path_parts: Vec<&str> = request.path.split('/').collect();
+
+    let page = path_parts[1]; // Assuming path format is "/community/webassemblymusic"
+    let handle = path_parts[2];
+
+
+    let redirect_url = format!("https://near.social/devhub.near/widget/app?page={}&handle={}", page, handle);
+
+    let body = format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Your Website Title</title>
+    <meta property="og:url" content="{url}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Your Title Here" />
+    <meta property="og:description" content="Your description here" />
+    <meta property="og:image" content="https://example.com/image.jpg" />
+
+    <!-- Additional tags for Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Your Title Here">
+    <meta name="twitter:description" content="Your description here">
+    <meta name="twitter:image" content="https://example.com/image.jpg">
+</head>
+<body>
+    <h1>Hello, check out this link:</h1>
+    <a href="{url}">Visit our page</a>
+</body>
+</html>"#,
+        url = redirect_url
+    );
+
+    Web4Response::Body {
+        content_type: "text/html; charset=UTF-8".to_owned(),
+        body: BASE64_ENGINE.encode(body),
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use crate::web4::types::Web4Response;
+    use super::web4_get;
+
+    #[test]
+    pub fn test_web4() {
+        let response = web4_get(serde_json::from_value(serde_json::json!({
+            "path": "/community/webassemblymusic"
+        })).unwrap());
+        match response {
+            Web4Response::Body { content_type, body } => {
+                println!("Content Type: {}", content_type);
+                println!("Body: {}", body);
+            },
+            Web4Response::BodyUrl { body_url } => {
+                println!("Body is located at URL: {}", body_url);
+            },
+            Web4Response::PreloadUrls { preload_urls } => {
+                println!("Preloaded URLs: {:?}", preload_urls);
+            },
+        }
+    }
+}

--- a/src/web4/mod.rs
+++ b/src/web4/mod.rs
@@ -1,0 +1,2 @@
+pub mod handler;
+pub mod types;

--- a/src/web4/types.rs
+++ b/src/web4/types.rs
@@ -1,0 +1,33 @@
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::NearSchema;
+
+#[derive(Debug, Serialize, Deserialize, NearSchema)]
+#[serde(crate = "near_sdk::serde")]
+pub struct Web4Request {
+    #[serde(rename = "accountId")]
+    pub account_id: Option<String>,
+    pub path: String,
+    #[serde(default)]
+    pub params: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub query: std::collections::HashMap<String, Vec<String>>,
+    pub preloads: Option<std::collections::HashMap<String, Web4Response>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, NearSchema)]
+#[serde(crate = "near_sdk::serde", untagged)]
+pub enum Web4Response {
+    Body {
+        #[serde(rename = "contentType")]
+        content_type: String,
+        body: String,
+    },
+    BodyUrl {
+        #[serde(rename = "bodyUrl")]
+        body_url: String,
+    },
+    PreloadUrls {
+        #[serde(rename = "preloadUrls")]
+        preload_urls: Vec<String>,
+    },
+}

--- a/tests/snapshots/migration__deploy_contract_self_upgrade-8.snap
+++ b/tests/snapshots/migration__deploy_contract_self_upgrade-8.snap
@@ -17,5 +17,20 @@ expression: get_community
   "telegram_handle": null,
   "twitter_handle": null,
   "website_url": null,
-  "addons": []
+  "addons": [
+    {
+      "id": "announcements",
+      "addon_id": "announcements",
+      "display_name": "Announcements",
+      "enabled": true,
+      "parameters": ""
+    },
+    {
+      "id": "discussions",
+      "addon_id": "discussions",
+      "display_name": "Discussions",
+      "enabled": true,
+      "parameters": ""
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds the `web4_get` method to the contract, so that when merged, there will be a website at https://devhub.near.page

You can preview it at https://devhublink.testnet.page/

<img width="612" alt="image" src="https://github.com/NEAR-DevHub/neardevhub-contract/assets/9760441/c0457ee5-df36-4549-97c2-a6a1a5fb77b3">

Note that the preview deployment does not have access to content, so it will not be able to display proper content for preview links, which is provided by the contract. A test community "webassemblymusic" is created for the preview deployment, to demonstrate the preview links. You can test it at https://devhublink.testnet.page/community/webassemblymusic. You may also call the preview contract to create proposals and other communities to verify that social media headers are also populated with the content.

For now the first part of the part is always mapped to the `page` property, so that e.g. `/proposals` are translated to `/devhub.near/widget/app?page=proposals`. Also the second part translates to `handle` for community ( `/community/webassemblymusic` -> `/devhub.near/widget/app?page=community&handle=webassemblymusic` ), or to `id` for proposal `/proposal/5` -> `/devhub.near/widget/app?page=proposal&id=5`

In addition to metadata for social media links, and SEO friendly URLs, the actual content is viewed as well. This is done using [near-bos-webcomponent](https://github.com/NEARBuilders/near-bos-webcomponent/pull/10) which is also used for playwright tests in the DevHub frontend. A PR have also been created there to support the SEO friendly URL paths created here.

The `html-escape` crate is added to ensure that descriptions with html tags are escaped for the generated HTML ( to avoid malicious scripts etc ).

Examples:

- https://devhublink.testnet.page/community/webassemblymusic ( This community is also created in the testnet contract )
- https://devhublink.testnet.page/community/chain-abstraction ( not created in the testnet contract, so metadata is missing, but the content shows )
- https://devhublink.testnet.page/proposal/0 ( Also has a proposal created in the testnet contract )
- https://devhublink.testnet.page/proposal/3 ( not created in the testnet contract, so metadata is missing, but the content shows )

Part of https://github.com/NEAR-DevHub/neardevhub-bos/issues/724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `web4` module to handle web requests, dynamically generate HTML content, and encode responses.
	- Added a public function for fetching web content based on request paths, enhancing user interaction with community and proposal pages.

- **Documentation**
	- Enhanced documentation for new web request handling functionality.

- **Dependencies**
	- Added `html-escape` library to support HTML content generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->