### PR TITLE
Fix post 606 by switching supervisor from AccountId to String in Sponsorship

### DIFF
--- a/src/post/sponsorship.rs
+++ b/src/post/sponsorship.rs
@@ -44,7 +44,7 @@ pub struct Sponsorship {
         deserialize_with = "u128_dec_format::deserialize"
     )]
     pub amount: Balance,
-    pub supervisor: AccountId,
+    pub supervisor: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, NearSchema)]
@@ -59,7 +59,7 @@ pub struct SponsorshipV1 {
         deserialize_with = "u128_dec_format::deserialize"
     )]
     pub amount: Balance,
-    pub supervisor: AccountId,
+    pub supervisor: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, NearSchema)]


### PR DESCRIPTION
When trying to get post 606
```bash
near contract \
    call-function \
    as-read-only devgovgigs.near get_post \
    json-args '{"post_id": 606}' \
    network-config pagoda-mainnet \
    now
```
The error occurs:
```
Error: 
   0: Failed to fetch query for view method: 'get_post' (contract <devgovgigs.near> on network <mainnet>)
   1: Failed to make a view-function call
   2: handler error: [Function call returned an error: wasm execution failed with error: HostError(GuestPanic { panic_msg: "Cannot deserialize element" })]
```

Note: [add_post](https://pikespeak.ai/transaction-viewer/K8o1KxdcpxRjtYobHi6tMEDTyqc51yBoNdLBtVMrNZD/detailed) transaction

Here is why:
 - This PR updates near-sdk-rs from version 3.1.0 to version 4.1.1 https://github.com/NEAR-DevHub/neardevhub-contract/commit/b06629b7694a05c12e7bd4ba570113b12dde073e
 - near-sdk-rs version 3.1.0 uses near-primitives-core version 0.4.0 where AccountId is [defined](https://github.com/near/nearcore/blob/c72b1ebfcc4a482ad2b032dedad2402d96b56e1a/core/primitives-core/src/types.rs#L4) as a string 
 - In near-sdk-rs 4.1.1 AccountId [became](https://github.com/near/near-sdk-rs/blob/4.1.1/near-sdk/src/types/account_id.rs
) a type with checks if account is valid

So before the change it was possible to add a post with empty [supervisor](https://github.com/NEAR-DevHub/neardevhub-contract/blob/83e4db344dc3d049fc6eb7d4bdc79508e349141e/src/post/sponsorship.rs#L62):
```bash
near contract \                        
    call-function \
    as-transaction test_606_from_9829f4.testnet add_post \
    json-args '{
  "body": {
    "name": "Kyiv Tech Summit 2023: Web3 Hackathon+Conference",
    "amount": "30000",
    "post_type": "Sponsorship",
    "supervisor": "",         
    "description": "sponsorship on old version without supervisor",
    "sponsorship_token": "USD",
    "sponsorship_version": "V1"
  },
  "labels": [
    "hackathon"
  ]
}' \
    prepaid-gas '300 Tgas' \
    attached-deposit '0.1 NEAR' \
    sign-as test_606_from_9829f4.testnet  \
    network-config testnet \
    sign-with-keychain \
    send
```

After the change, it became invalid

So, in this PR supervisor field's type is changed from AccountId to simple String. So that there is no type check. It does not break anything. And I don't provide migration as Sponsorship is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the supervisor field in sponsorship-related features from an account ID to a string for enhanced flexibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->