### PR TITLE
Devgovgigs: fix post 606 by switching supervisor from AccountId to String in Sponsorship

### DIFF
--- a/src/post/sponsorship.rs
+++ b/src/post/sponsorship.rs
@@ -33,7 +33,7 @@ pub struct Sponsorship {
     pub sponsorship_token: SponsorshipToken,
     #[serde(with = "u128_dec_format")]
     pub amount: Balance,
-    pub supervisor: AccountId,
+    pub supervisor: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
@@ -44,7 +44,7 @@ pub struct SponsorshipV1 {
     pub sponsorship_token: SponsorshipToken,
     #[serde(with = "u128_dec_format")]
     pub amount: Balance,
-    pub supervisor: AccountId,
+    pub supervisor: String,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Same PR for devhub.near: https://github.com/NEAR-DevHub/neardevhub-contract/pull/113

Last unsafe_safe_upgrade call to devgovgigs.near: https://pikespeak.ai/transaction-viewer/3oUq3cf4cirUVCDaLscr83askUTQNAtLkCTrzFTouEKf/detailed

PR connected to it: https://github.com/NEAR-DevHub/neardevhub-contract/pull/77

Last unsafe_migrate is close to that block as well. Last contract deploy on Jan 2023. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Changed the format of the `supervisor` field in sponsorship data from `AccountId` to `String` for improved compatibility and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->