### PR TITLE
social media links title and description from socialdb app widget metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ use crate::access_control::members::ActionType;
 use crate::access_control::members::Member;
 use crate::access_control::AccessControl;
 use community::*;
-use near_sdk::json_types::Base64VecU8;
 use post::*;
 use proposal::timeline::TimelineStatus;
 use proposal::*;

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -23,7 +23,10 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     // are always [0] and [1] elements, and [0] is always empty.
     let page = path_parts[1];
 
-    let metadata_preload_url = format!("https://rpc.web4.near.page/account/social.near/view/get?keys.json=[%22{}/widget/app/metadata/**%22]", env::current_account_id());
+    let metadata_preload_url = format!(
+        "/web4/contract/social.near/get?keys.json=%5B%22{}/widget/app/metadata/**%22%5D",
+        env::current_account_id()
+    );
 
     let mut title = String::from("near/dev/hub");
     let mut description = String::from("The decentralized home base for NEAR builders");
@@ -178,7 +181,7 @@ mod tests {
         base64::Engine, serde_json::json, test_utils::VMContextBuilder, testing_env, NearToken,
     };
 
-    const PRELOAD_URL: &str = "https://rpc.web4.near.page/account/social.near/view/get?keys.json=[%22not-only-devhub.near/widget/app/metadata/**%22]";
+    const PRELOAD_URL: &str = "/web4/contract/social.near/get?keys.json=%5B%22not-only-devhub.near/widget/app/metadata/**%22%5D";
 
     fn create_preload_result(title: String, description: String) -> serde_json::Value {
         let body_string = serde_json::json!({"not-only-devhub.near":{"widget":{"app":{"metadata":{

--- a/src/web4/types.rs
+++ b/src/web4/types.rs
@@ -14,7 +14,7 @@ pub struct Web4Request {
     pub preloads: Option<std::collections::HashMap<String, Web4Response>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, NearSchema)]
+#[derive(Debug, Serialize, Deserialize, NearSchema, Clone)]
 #[serde(crate = "near_sdk::serde", untagged)]
 pub enum Web4Response {
     Body {


### PR DESCRIPTION
Get title and description for social media  landing page from socialdb, by using web4 preloads querying social db.

You can verify the functionality in the deployment to `peterdevhub.near` where you can see that the description is set according to the data registered in socialdb.

```
curl https://peterdevhub.near.page
```

<img width="1144" alt="image" src="https://github.com/NEAR-DevHub/neardevhub-contract/assets/9760441/6dfe51c8-145b-4442-9be5-b5e13473b672">

The preload url being used is:

https://rpc.web4.near.page/account/social.near/view/get?keys.json=[%22peterdevhub.near/widget/app/metadata/**%22]

where you can see that `name` and `description` from the returned payload matches the title and description in the preview environment metadata tags.

fixes #135 