### PR TITLE
switch to fastnear rpc for web4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
     "image": "ghcr.io/near/near-devcontainer:latest",
     "features": {
       "ghcr.io/near/near-devcontainers/features/cargo-near:latest": {},
-      "ghcr.io/near/near-devcontainers/features/near-cli:latest": {}
+      "ghcr.io/near/near-devcontainers/features/near-cli:latest": {},
+      "ghcr.io/devcontainers/features/rust:1": {}    
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,1 @@
 #!/bin/bash
-
-(cd community-factory && cargo near build)
-cargo near build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Build community factory contract
         run: cd community-factory && cargo near build non-reproducible-wasm
       - name: Build devhub contract
-        run: cargo near build
+        run: cargo near build non-reproducible-wasm
       - name: Unit tests
         run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install cargo-near
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
       - name: Build community factory contract
-        run: cd community-factory && cargo near build
+        run: cd community-factory && cargo near build non-reproducible-wasm
       - name: Build devhub contract
         run: cargo near build
       - name: Unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Install cargo-near
       run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
     - name: Build community factory contract
-      run: cd community-factory && cargo near build
+      run: cd community-factory && cargo near build non-reproducible-wasm
     - name: Build devhub contract
-      run: cargo near build
+      run: cargo near build non-reproducible-wasm
     - name: Install near CLI
       run: |
         curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.3.1/near-cli-rs-v0.3.1-installer.sh | sh

--- a/src/web4/handler.rs
+++ b/src/web4/handler.rs
@@ -183,8 +183,8 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
     <meta name="twitter:title" content="{app_name}{title}">
     <meta name="twitter:description" content="{description}">
     <meta name="twitter:image" content="{image}">
-    <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/main.794b6347ae264789bc61.bundle.js"></script>
-    <script src="https://ipfs.web4.near.page/ipfs/bafybeic6aeztkdlthx5uwehltxmn5i6owm47b7b2jxbbpwmydv2mwxdfca/runtime.25b143da327a5371509f.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/near-bos-webcomponent@0.0.9/dist/main.1b3f0d7d1017de355a7c.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/near-bos-webcomponent@0.0.9/dist/runtime.25b143da327a5371509f.bundle.js"></script>
     <style>
         @media screen and (max-width: 600px) {{
             .gatewaylinks .nav-link {{
@@ -212,7 +212,7 @@ pub fn web4_get(contract: &Contract, request: Web4Request) -> Web4Response {
         </a>
     </div>
 </nav>
-    <near-social-viewer src="{current_account_id}/widget/app" initialProps='{initial_props_json}'></near-social-viewer>
+    <near-social-viewer src="{current_account_id}/widget/app" initialProps='{initial_props_json}' rpc="https://rpc.mainnet.fastnear.com"></near-social-viewer>
     <script src="/resources/{web4_resource_account}/web4browserclient.js?blockHeight={web4_browserclient_block_height}"></script>
 </body>
 </html>"#,


### PR DESCRIPTION
- switch to rpc.mainnet.fastnear.com for web4 BOS viewer
- add `non-reproducible-wasm` parameter to `cargo near build` in workflows
- add `rust:1` feature to devcontainer configuration, and remove post-create building commands ( to reduce devcontainer startup time )

fixes #161